### PR TITLE
Add Cypress e2e tests

### DIFF
--- a/cypress/e2e/createTemplate.cy.ts
+++ b/cypress/e2e/createTemplate.cy.ts
@@ -1,0 +1,31 @@
+describe('Create habit template', () => {
+  beforeEach(() => {
+    cy.window().then((win) => win.localStorage.setItem('token', 'test-token'));
+    cy.visit('/#/create-template');
+  });
+
+  it('fills form and sends request', () => {
+    cy.intercept('POST', '**/habits/templates', { statusCode: 200 }).as('create');
+
+    cy.get('input[type="text"]').eq(0).type('Leer');
+    cy.get('input[type="text"]').eq(1).type('Leer un libro');
+
+    cy.get('select').eq(0).select('running');
+    cy.get('select').eq(1).select('#A4B1FF');
+    cy.get('select').eq(2).select('Healthy');
+    cy.get('select').eq(3).select('Build');
+    cy.get('select').eq(4).select('Diariamente');
+
+    cy.get('input[type="number"]').type('1');
+
+    cy.get('select').eq(5).select('veces');
+    cy.get('select').eq(6).select('Lunes');
+
+    cy.get('input[type="time"]').type('08:30');
+
+    cy.get('select').eq(7).select('Misión');
+
+    cy.contains('button', 'Guardar').click();
+    cy.wait('@create');
+  });
+});

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -2,7 +2,7 @@ const useMock = Cypress.env('useMock') === true || Cypress.env('useMock') === 't
 
 describe('Login page', () => {
   beforeEach(() => {
-    cy.visit('/login');
+    cy.visit('/#/login');
   });
 
   it('muestra un mensaje de error si los campos están vacíos', () => {
@@ -11,44 +11,36 @@ describe('Login page', () => {
   });
 
   it('muestra error si el backend responde con error', () => {
-    if (useMock) {
-      cy.intercept('POST', '**/auth/login', {
-        statusCode: 401,
-        body: {
-          message: 'Unauthorized',
-        },
-      }).as('loginFail');
-    }
+    cy.intercept('POST', '**/auth/login', {
+      statusCode: 401,
+      body: {
+        message: 'Unauthorized',
+      },
+    }).as('loginFail');
 
     cy.get('input[type="email"]').type('invalido@example.com');
     cy.get('input[type="password"]').type('wrongpassword');
     cy.get('button[type="submit"]').click();
 
-    if (useMock) {
-      cy.wait('@loginFail');
-    }
+    cy.wait('@loginFail');
 
     cy.contains('Credenciales inválidas o error del servidor').should('be.visible');
   });
 
   it('realiza login exitoso y redirige al dashboard', () => {
-    if (useMock) {
-      cy.intercept('POST', '**/auth/login', {
-        statusCode: 200,
-        body: {
-          access_token: 'fake-jwt-token',
-        },
-      }).as('loginSuccess');
-    }
+    cy.intercept('POST', '**/auth/login', {
+      statusCode: 200,
+      body: {
+        access_token: 'fake-jwt-token',
+      },
+    }).as('loginSuccess');
 
     cy.get('input[type="email"]').type('antonio.doberti@uc.cl');
     cy.get('input[type="password"]').type('admin123');
     cy.get('button[type="submit"]').click();
 
-    if (useMock) {
-      cy.wait('@loginSuccess');
-    }
+    cy.wait('@loginSuccess');
 
-    cy.url().should('include', '/dashboard');
+    cy.url().should('include', '#/dashboard');
   });
 });

--- a/cypress/e2e/logout.cy.ts
+++ b/cypress/e2e/logout.cy.ts
@@ -1,0 +1,17 @@
+const useMock = Cypress.env('useMock') === true || Cypress.env('useMock') === 'true';
+
+describe('Logout functionality', () => {
+  beforeEach(() => {
+    // set token to simulate logged in user
+    cy.window().then((win) => win.localStorage.setItem('token', 'test-token'));
+    cy.visit('/#/dashboard');
+  });
+
+  it('removes token and redirects to login', () => {
+    cy.contains('Cerrar sesión').click();
+    cy.url().should('include', '#/login');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
+});

--- a/cypress/e2e/privateRoute.cy.ts
+++ b/cypress/e2e/privateRoute.cy.ts
@@ -1,0 +1,19 @@
+const useMock = Cypress.env('useMock') === true || Cypress.env('useMock') === 'true';
+
+describe('Private routes', () => {
+  beforeEach(() => {
+    // ensure logged out by default
+    cy.window().then((win) => win.localStorage.removeItem('token'));
+  });
+
+  it('redirects unauthenticated users to login', () => {
+    cy.visit('/#/dashboard');
+    cy.url().should('include', '#/login');
+  });
+
+  it('allows access when token exists', () => {
+    cy.window().then((win) => win.localStorage.setItem('token', 'test-token'));
+    cy.visit('/#/dashboard');
+    cy.url().should('include', '#/dashboard');
+  });
+});

--- a/cypress/e2e/sidebarNavigation.cy.ts
+++ b/cypress/e2e/sidebarNavigation.cy.ts
@@ -1,0 +1,17 @@
+describe('Sidebar navigation', () => {
+  beforeEach(() => {
+    cy.window().then((win) => win.localStorage.setItem('token', 'test-token'));
+    cy.visit('/#/dashboard');
+  });
+
+  it('navigates to Templates page', () => {
+    cy.contains('Plantillas de Hábitos').click();
+    cy.url().should('include', '#/templates');
+    cy.contains('Plantillas').should('be.visible');
+  });
+
+  it('navigates to Analytics page', () => {
+    cy.contains('Analytics').click();
+    cy.url().should('include', '#/dashboard/analytics');
+  });
+});


### PR DESCRIPTION
## Summary
- add new e2e tests covering private routing, logout, sidebar navigation and template creation
- update login test logic

## Testing
- `CYPRESS_baseUrl=http://localhost:5176 npx cypress run`

------
https://chatgpt.com/codex/tasks/task_e_686c002b498c832fbc1163eb925415f5